### PR TITLE
authors update

### DIFF
--- a/src/data/author.json
+++ b/src/data/author.json
@@ -5,5 +5,12 @@
     "email": "",
     "web": "",
     "twitter": ""
+  },
+  {
+    "id": "Michal Takac",
+    "info": "",
+    "email": "",
+    "web": "",
+    "twitter": ""
   }
 ]


### PR DESCRIPTION
To show author's name they have to be added to `src/data/author.json`. Information is automatically linked to blogpost author. Feel free to add more info about yourself. I'll display it on site later (TBD).