### PR TITLE
add tippin.me widget for parallelpoliske [#84]

### DIFF
--- a/src/components/TippinWidget.jsx
+++ b/src/components/TippinWidget.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const TippinWidget = () => {
+  return <iframe title="Tippin.me widget" src="https://tippin.me/buttons/send-lite.php?u=parallelpoliske" height="475px" />
+}

--- a/src/pages/zapoj-sa/podpora.mdx
+++ b/src/pages/zapoj-sa/podpora.mdx
@@ -6,6 +6,7 @@ image: /ppke-join.png
 
 import { Button } from '../../components/Button';
 import { CryptoAddresses } from '../../components/CryptoAddresses';
+import { TippinWidget } from '../../components/TippinWidget';
 
 ## Sme nezisková organizácia, nezávislá na štátnych peniazoch. Pri našej snahe sú dôležité (aj tvoje) dobrovoľné príspevky.
 
@@ -20,6 +21,10 @@ Práve preto potrebujeme každú pomoc – od fanúšikov a ľudí, ktorí sa v�
 Príspevky prijímame na:
 
 <CryptoAddresses />
+
+**BTC** cez **Lightning Network** jednoducho pomocou služby Tippin.me:
+
+<TippinWidget />
 
 Za každú pomoc **úprimne ďakujeme**!
 


### PR DESCRIPTION
Closes #84.

Tippin.me as a widget inside `<iframe>`. No additional `tip.js` loaded (because this is not a button opening a modal).

![Screen Shot 2019-04-01 at 21 34 04](https://user-images.githubusercontent.com/6513576/55354417-fc517c80-54c5-11e9-81b7-237b47d2cf14.jpg)
