### PR TITLE
feat: obrázky eventov + tlačidlo kúpiť lístky len pre budúce akcie

### DIFF
--- a/src/components/NewsCard.astro
+++ b/src/components/NewsCard.astro
@@ -2,11 +2,20 @@
 const { post } = Astro.props;
 
 const { Content } = await post.render();
+const { image, purchaseLink, pubDate } = post.data;
+
+const isFuture = pubDate && new Date(pubDate) > new Date();
 ---
 
 <section class="card-container">
   <div class="card">
+    {image && <img src={image} alt={post.data.title} class="card-image" />}
     <Content />
+    {isFuture && purchaseLink && (
+      <a href={purchaseLink} target="_blank" rel="noopener noreferrer" class="buy-btn">
+        Kúpiť lístky
+      </a>
+    )}
   </div>
 </section>
 
@@ -31,6 +40,29 @@ const { Content } = await post.render();
     &:hover {
       box-shadow: 9px 9px 0 black;
       translate: -5px -5px;
+    }
+  }
+
+  .card-image {
+    width: 100%;
+    height: auto;
+    display: block;
+    margin-bottom: 1em;
+  }
+
+  .buy-btn {
+    display: inline-block;
+    margin-top: 1em;
+    padding: 0.5em 1.25em;
+    background: black;
+    color: white;
+    text-decoration: none;
+    font-size: var(--step--1);
+    font-family: inherit;
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: #333;
     }
   }
 </style>

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -16,6 +16,8 @@ export const collections = {
     schema: z.object({
       title: z.string(),
       pubDate: z.date(),
+      image: z.string().optional(),
+      purchaseLink: z.string().optional(),
     }),
   }),
   'join-us': defineCollection({

--- a/src/content/news/2025-06-24-web3-pre-bitcoinera.md
+++ b/src/content/news/2025-06-24-web3-pre-bitcoinera.md
@@ -1,6 +1,8 @@
 ---
 title: "Web3 pre Bitcoinera"
 pubDate: 2025-06-24
+image: "https://shop.ppke.sk/LocalStorage/300d68c8-ff28-41f4-8615-36cc3752d5f9-web3_for_bitcoiner_2.jpg"
+purchaseLink: "https://shop.ppke.sk/plugins/NhzrpLAMZY4YAUKwhLpJjpNgBVHao3C4VNAYNnj4VAT/ticket/public/event/03991846-0e1c-499c-84c1-0811d757c919/summary"
 ---
 
 ### Web3 pre Bitcoinera

--- a/src/content/news/2025-10-23-anatomia-kybernetickeho-utoku.md
+++ b/src/content/news/2025-10-23-anatomia-kybernetickeho-utoku.md
@@ -1,6 +1,8 @@
 ---
 title: "Anatómia kybernetického útoku"
 pubDate: 2025-10-23
+image: "https://shop.ppke.sk/LocalStorage/f4660964-1ec2-4d57-8a70-e498360fef4a-signal-2025-10-06-154641.jpeg"
+purchaseLink: "https://shop.ppke.sk/plugins/NhzrpLAMZY4YAUKwhLpJjpNgBVHao3C4VNAYNnj4VAT/ticket/public/event/0e852b17-9231-4ba7-9b08-20d6c852086d/summary"
 ---
 
 ### Anatómia kybernetického útoku

--- a/src/content/news/2025-12-10-cashu-chaumian-ecash.md
+++ b/src/content/news/2025-12-10-cashu-chaumian-ecash.md
@@ -1,6 +1,8 @@
 ---
 title: "Cashu - Chaumian eCash nad Bitcoinom"
 pubDate: 2025-12-10
+image: "https://shop.ppke.sk/LocalStorage/c1af6f8f-aaa5-408c-968d-396abdd4c95c-image.jpg"
+purchaseLink: "https://shop.ppke.sk/plugins/NhzrpLAMZY4YAUKwhLpJjpNgBVHao3C4VNAYNnj4VAT/ticket/public/event/89793083-a1c7-452c-a04e-5507b45e1e52/summary"
 ---
 
 ### Cashu - Chaumian eCash nad Bitcoinom

--- a/src/content/news/2026-03-09-vexl-bitcoin-p2p.md
+++ b/src/content/news/2026-03-09-vexl-bitcoin-p2p.md
@@ -1,6 +1,8 @@
 ---
 title: "VEXL - Bitcoin P2P bez KYC"
 pubDate: 2026-03-09
+image: "https://shop.ppke.sk/LocalStorage/04b5bf07-17b6-4ef6-9372-653b4bcd3aa6-flux2-klein_00050_.jpg"
+purchaseLink: "https://shop.ppke.sk/plugins/NhzrpLAMZY4YAUKwhLpJjpNgBVHao3C4VNAYNnj4VAT/ticket/public/event/efe2e2d8-c0fb-401e-af02-4dafaaf544d7/summary"
 ---
 
 ### VEXL - Bitcoin P2P bez KYC

--- a/src/content/news/2026-04-01-prechadzka-latentnym-priestorom.md
+++ b/src/content/news/2026-04-01-prechadzka-latentnym-priestorom.md
@@ -1,6 +1,8 @@
 ---
 title: "Prechádzka latentným priestorom"
 pubDate: 2026-04-01
+image: "https://shop.ppke.sk/LocalStorage/f0d6cc57-c453-4070-a1e2-713e5096b8e5-output.gif"
+purchaseLink: "https://shop.ppke.sk/plugins/NhzrpLAMZY4YAUKwhLpJjpNgBVHao3C4VNAYNnj4VAT/ticket/public/event/ed0cb32a-d56a-4f43-8918-2c37d483f8c3/summary"
 ---
 
 ### Prechádzka latentným priestorom


### PR DESCRIPTION
## Zmeny

- Každá akcia teraz zobrazuje obrázok z BTCPayServer Satoshi Tickets
- Tlačidlo **Kúpiť lístky** sa zobrazuje iba na eventoch, ktoré ešte nenastali
- Rozšírená content schema (`news` collection) o voliteľné polia `image` a `purchaseLink`
- Všetkých 5 eventov má priradený obrázok a odkaz na nákup lístkov

## Test

- `astro build` prechádza bez chýb
- Logika: `isFuture = new Date(pubDate) > new Date()` — tlačidlo sa nezobrazí pre minulé eventy

🤖 Generated with [Claude Code](https://claude.com/claude-code)