### PR TITLE
Remove invalid events.ppke@proton.me contact email

### DIFF
--- a/src/pages/kontakt.mdx
+++ b/src/pages/kontakt.mdx
@@ -11,7 +11,6 @@ import src from "../../public/space/hero-contact.jpg";
 <div class="maxcontent">
 - Sociálne siete <Social />
 - [info@ppke.sk](mailto:info@ppke.sk)
-- [events.ppke@proton.me](mailto:events.ppke@proton.me) - event management
 - [Zapoj sa](/zapoj-sa)
 
 <Card>


### PR DESCRIPTION
## Summary

- Removes the inactive `events.ppke@proton.me` email from the contact page (`kontakt.mdx`)
- The address is no longer valid and was causing confusion for visitors

## Changes

- `src/pages/kontakt.mdx`: Removed the events email line from the contact list

## Test plan

- [x] Verify contact page renders correctly without the removed email
- [x] Check no other references to this email remain on the site